### PR TITLE
Fix api url change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Papermcdl
 
+> [!WARNING]
+> At the moment it is not possible to see which versions are stable and which are beta. (Related issue)[https://github.com/jonas-be/papermcdl/issues/4]
+
 Download all PaperMC projects with ease using _papermcdl_.
 Choose between a user-friendly [GUI](#gui) or [command-line flags](#cli-with-flags) to streamline the process.
 Perfect for developers and Minecraft server admins.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Papermcdl
 
 > [!WARNING]
-> At the moment it is not possible to see which versions are stable and which are beta. (Related issue)[https://github.com/jonas-be/papermcdl/issues/4]
+> At the moment it is not possible to see which versions are stable and which are beta. [Related issue](https://github.com/jonas-be/papermcdl/issues/4)
 
 Download all PaperMC projects with ease using _papermcdl_.
 Choose between a user-friendly [GUI](#gui) or [command-line flags](#cli-with-flags) to streamline the process.

--- a/cmd/papermcdl/main.go
+++ b/cmd/papermcdl/main.go
@@ -16,7 +16,7 @@ func main() {
 	infoFlag := flag.Bool("i", false, "(Optional) Show info or list available only.")
 	flag.Parse()
 
-	papermcAPI := paper_api.PapermcAPI{URL: "https://papermc.io"}
+	papermcAPI := paper_api.PapermcAPI{URL: "https://fill.papermc.io/v2"}
 
 	if *projectFlag == "" && *versionFlag == "" && *buildFlag == "l" && *infoFlag == false {
 		gui.StartGUI(papermcAPI)

--- a/internal/gui/papermc/downloader.go
+++ b/internal/gui/papermc/downloader.go
@@ -97,7 +97,7 @@ func PrintDownloadPercent(done chan int64, path string, total int64, s tcell.Scr
 
 			var percent float64 = float64(size) / float64(total) * 100
 
-			screen.FullWidthField(s, fmt.Sprintf("%.0f%", percent), line)
+			screen.FullWidthField(s, fmt.Sprintf("%.0f%%", percent), line)
 
 			writerPos := 0
 			w, _ := s.Size()

--- a/internal/gui/papermc/papermc_selector.go
+++ b/internal/gui/papermc/papermc_selector.go
@@ -165,7 +165,7 @@ func (p PapermcSelector) versionGroupFilter(versions paper_api.Versions, version
 func (p *PapermcSelector) selectAndTagLatest() {
 	id, item, err := latest.GetLatestItem(p.List.List)
 	if err == nil {
-		p.List.Tags = []list.Tag{{Label: "latest/stable", ItemName: item}}
+		p.List.Tags = []list.Tag{{Label: "latest", ItemName: item}}
 		p.List.Selected = id
 	}
 }

--- a/pkg/paper_api/build_info.go
+++ b/pkg/paper_api/build_info.go
@@ -39,7 +39,7 @@ func (b BuildInfo) PrintBuildInfo() {
 }
 
 func (p PapermcAPI) GetBuildInfo(project string, version string, build string) (BuildInfo, error) {
-	res, err := p.sendRequest(fmt.Sprintf("/api/v2/projects/%v/versions/%v/builds/%v", project, version, build))
+	res, err := p.sendRequest(fmt.Sprintf("/projects/%v/versions/%v/builds/%v", project, version, build))
 	if err != nil {
 		return BuildInfo{}, err
 	}

--- a/pkg/paper_api/build_info_test.go
+++ b/pkg/paper_api/build_info_test.go
@@ -10,7 +10,7 @@ func TestPapermcAPI_GetBuildInfo(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder("GET", "https://papermc.io/api/v2/projects/velocity/versions/3.1.1/builds/445",
+	httpmock.RegisterResponder("GET", "https://fill.papermc.io/v2/projects/velocity/versions/3.1.1/builds/445",
 		httpmock.NewStringResponder(200, "{\"project_id\":\"paper\",\"project_name\":\"Paper\",\"version\":\"1.8.8\",\"build\":445,\"time\":\"2021-12-20T00:10:48.936Z\",\"channel\":\"default\",\"promoted\":false,\"changes\":[{\"commit\":\"2ce7ea620a6d9590a9f93b47ac45e240dac7988a\",\"summary\":\"Update\",\"message\":\"Update\"}],\"downloads\":{\"application\":{\"name\":\"paper-1.8.8-445.jar\",\"sha256\":\"7ff6d2cec671ef0d95b3723b5c92890118fb882d73b7f8fa0a2cd31d97c55f86\"}}}"))
 
 	want := BuildInfo{
@@ -49,7 +49,7 @@ func TestPapermcAPI_GetBuildInfo(t *testing.T) {
 	}
 
 	p := PapermcAPI{
-		URL: "https://papermc.io",
+		URL: "https://fill.papermc.io/v2",
 	}
 	builds, err := p.GetBuildInfo("velocity", "3.1.1", "445")
 	if err != nil {

--- a/pkg/paper_api/builds.go
+++ b/pkg/paper_api/builds.go
@@ -29,7 +29,7 @@ func (b Builds) GetLatestBuild() (string, error) {
 }
 
 func (p PapermcAPI) GetBuilds(project string, version string) (Builds, error) {
-	res, err := p.sendRequest(fmt.Sprintf("/api/v2/projects/%v/versions/%v", project, version))
+	res, err := p.sendRequest(fmt.Sprintf("/projects/%v/versions/%v", project, version))
 	if err != nil {
 		return Builds{}, err
 	}

--- a/pkg/paper_api/builds_test.go
+++ b/pkg/paper_api/builds_test.go
@@ -10,7 +10,7 @@ func TestPapermcAPI_GetBuilds(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder("GET", "https://papermc.io/api/v2/projects/velocity/versions/3.1.1",
+	httpmock.RegisterResponder("GET", "https://fill.papermc.io/v2/projects/velocity/versions/3.1.1",
 		httpmock.NewStringResponder(200, "{\"project_id\":\"velocity\",\"project_name\":\"Velocity\",\"version\":\"3.1.1\",\"builds\":[98,99,102]}"))
 
 	want := Builds{
@@ -21,7 +21,7 @@ func TestPapermcAPI_GetBuilds(t *testing.T) {
 	}
 
 	p := PapermcAPI{
-		URL: "https://papermc.io",
+		URL: "https://fill.papermc.io/v2",
 	}
 	builds, err := p.GetBuilds("velocity", "3.1.1")
 	if err != nil {

--- a/pkg/paper_api/download.go
+++ b/pkg/paper_api/download.go
@@ -16,7 +16,7 @@ func (p PapermcAPI) GetDownloadString(project string, version string, build stri
 	if err != nil {
 		return "", "", err
 	}
-	return fmt.Sprintf("%v/api/v2/projects/%v/versions/%v/builds/%v/downloads/%v",
+	return fmt.Sprintf("%v/projects/%v/versions/%v/builds/%v/downloads/%v",
 		p.URL, project, version, build, p.GetFileName(buildInfo)), p.GetFileName(buildInfo), nil
 }
 

--- a/pkg/paper_api/download_test.go
+++ b/pkg/paper_api/download_test.go
@@ -10,18 +10,18 @@ func TestPapermcAPI_GetDownloadString(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder("GET", "https://papermc.io/api/v2/projects/paper/versions/1.8.8/builds/445",
+	httpmock.RegisterResponder("GET", "https://fill.papermc.io/v2/projects/paper/versions/1.8.8/builds/445",
 		httpmock.NewStringResponder(200, "{\"project_id\":\"paper\",\"project_name\":\"Paper\",\"version\":\"1.8.8\",\"build\":445,\"time\":\"2021-12-20T00:10:48.936Z\",\"channel\":\"default\",\"promoted\":false,\"changes\":[{\"commit\":\"2ce7ea620a6d9590a9f93b47ac45e240dac7988a\",\"summary\":\"Update\",\"message\":\"Update\"}],\"downloads\":{\"application\":{\"name\":\"paper-1.8.8-445.jar\",\"sha256\":\"7ff6d2cec671ef0d95b3723b5c92890118fb882d73b7f8fa0a2cd31d97c55f86\"}}}"))
 
 	p := PapermcAPI{
-		URL: "https://papermc.io",
+		URL: "https://fill.papermc.io/v2",
 	}
 	downloadString, fileName, err := p.GetDownloadString("paper", "1.8.8", "445")
 	if err != nil {
 		t.Errorf("GetDownloadString() unintentionally error = %v", err)
 		return
 	}
-	want := "https://papermc.io/api/v2/projects/paper/versions/1.8.8/builds/445/downloads/paper-1.8.8-445.jar"
+	want := "https://fill.papermc.io/v2/projects/paper/versions/1.8.8/builds/445/downloads/paper-1.8.8-445.jar"
 	if !reflect.DeepEqual(downloadString, want) {
 		t.Errorf("GetDownloadString() got = %v, want %v", downloadString, want)
 	}

--- a/pkg/paper_api/projects.go
+++ b/pkg/paper_api/projects.go
@@ -16,7 +16,7 @@ func (p Projects) PrintProjects() {
 }
 
 func (p PapermcAPI) GetProjects() (Projects, error) {
-	res, err := p.sendRequest("/api/v2/projects/")
+	res, err := p.sendRequest("/projects/")
 	if err != nil {
 		return Projects{}, err
 	}

--- a/pkg/paper_api/projects_test.go
+++ b/pkg/paper_api/projects_test.go
@@ -10,7 +10,7 @@ func TestPapermcAPI_GetProjects(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder("GET", "https://papermc.io/api/v2/projects/",
+	httpmock.RegisterResponder("GET", "https://fill.papermc.io/v2/projects/",
 		httpmock.NewStringResponder(200, "{\"projects\":[\"paper\",\"travertine\",\"waterfall\",\"velocity\",\"folia\"]}"))
 
 	want := Projects{Projects: []string{
@@ -22,7 +22,7 @@ func TestPapermcAPI_GetProjects(t *testing.T) {
 	}}
 
 	p := PapermcAPI{
-		URL: "https://papermc.io",
+		URL: "https://fill.papermc.io/v2",
 	}
 	projects, err := p.GetProjects()
 	if err != nil {

--- a/pkg/paper_api/versions.go
+++ b/pkg/paper_api/versions.go
@@ -37,7 +37,7 @@ func (v Versions) GetLatestVersionGroup() (string, error) {
 }
 
 func (p PapermcAPI) GetVersions(project string) (Versions, error) {
-	res, err := p.sendRequest("/api/v2/projects/" + project)
+	res, err := p.sendRequest("/projects/" + project)
 	if err != nil {
 		return Versions{}, err
 	}

--- a/pkg/paper_api/versions_test.go
+++ b/pkg/paper_api/versions_test.go
@@ -10,7 +10,7 @@ func TestPapermcAPI_GetVersions(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder("GET", "https://papermc.io/api/v2/projects/velocity",
+	httpmock.RegisterResponder("GET", "https://fill.papermc.io/v2/projects/velocity",
 		httpmock.NewStringResponder(200, "{\"project_id\":\"velocity\",\"project_name\":\"Velocity\",\"version_groups\":[\"1.0.0\",\"1.1.0\",\"3.0.0\"],\"versions\":[\"1.0.10\",\"1.1.9\",\"3.1.0\",\"3.1.1\",\"3.1.1-SNAPSHOT\",\"3.1.2-SNAPSHOT\",\"3.2.0-SNAPSHOT\"]}"))
 
 	want := Versions{
@@ -21,7 +21,7 @@ func TestPapermcAPI_GetVersions(t *testing.T) {
 	}
 
 	p := PapermcAPI{
-		URL: "https://papermc.io",
+		URL: "https://fill.papermc.io/v2",
 	}
 	versions, err := p.GetVersions("velocity")
 	if err != nil {


### PR DESCRIPTION
This PR fixes the base URL change of the API.
It also adds a hint that beta builds were not correctly flagged as beta.

Relates to https://github.com/jonas-be/papermcdl/issues/4